### PR TITLE
Force Node.js buildpack only - remove Python buildpack completely

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,14 +1,11 @@
 {
   "name": "Idaho Broadcasting Media Upload",
-  "description": "A Flask application for uploading and managing media files with Cloudinary and React frontend",
+  "description": "A Node.js application for uploading and managing media files with React frontend",
   "repository": "https://github.com/dmccolly/media-file-manager",
-  "keywords": ["flask", "python", "react", "media", "upload", "cloudinary"],
+  "keywords": ["nodejs", "react", "media", "upload", "express"],
   "buildpacks": [
     {
       "url": "heroku/nodejs"
-    },
-    {
-      "url": "heroku/python"
     }
   ],
   "env": {


### PR DESCRIPTION
- Remove heroku/python buildpack from app.json
- Update description and keywords to reflect Node.js application
- This forces Heroku to use only Node.js buildpack
- Should resolve cross-spawn dependency issue with NPM_CONFIG_PRODUCTION=false npm ci
- Will serve React build correctly via Express.js instead of Flask