### PR TITLE
Add missing API endpoints to resolve React app errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "compression": "^1.7.4",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "node-fetch": "^2.7.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -6,9 +6,44 @@ const app = express();
 const buildDir = path.join(__dirname, "build");
 
 app.use(compression());
+app.use(express.json());
 
 app.use("/static", express.static(path.join(buildDir, "static"), { maxAge: "1h", etag: true }));
-app.use("/assets", express.static(path.join(buildDir, "assets"), { maxAge: "1h", etag: true })); // (Vite-style if present)
+app.use("/assets", express.static(path.join(buildDir, "assets"), { maxAge: "1h", etag: true }));
+
+app.get("/api/media", async (req, res) => {
+  try {
+    const fetch = require('node-fetch');
+    const response = await fetch(`https://x8ki-letl-twmt.n7.xano.io/api:9JQKgXNj/media_records`, {
+      headers: {
+        'Authorization': `Bearer ${process.env.XANO_API_KEY}`,
+        'Content-Type': 'application/json'
+      }
+    });
+    
+    if (!response.ok) {
+      throw new Error(`Xano API error: ${response.status}`);
+    }
+    
+    const data = await response.json();
+    res.json(data);
+  } catch (error) {
+    console.error('API /media error:', error);
+    res.status(500).json({ error: 'Failed to fetch media records' });
+  }
+});
+
+app.post("/api/upload", async (req, res) => {
+  try {
+    res.json({ 
+      success: false, 
+      error: 'Upload endpoint not fully implemented in Express server' 
+    });
+  } catch (error) {
+    console.error('API /upload error:', error);
+    res.status(500).json({ error: 'Upload failed' });
+  }
+});
 
 app.get(["/manager", "/manager/*"], (req, res) => {
   res.type("html");


### PR DESCRIPTION
- Add /api/media endpoint to fetch from Xano API
- Add /api/upload placeholder endpoint
- Add node-fetch dependency for API calls
- Resolves React app 404 errors preventing proper interface display

Fixes raw code display issue by providing required backend endpoints